### PR TITLE
Fix sandbox space names

### DIFF
--- a/monitor_helper.rb
+++ b/monitor_helper.rb
@@ -24,7 +24,7 @@ module MonitorHelper
 
 	def get_sandbox_space_name(email)
 
-   		return email.split('@')[0]
+   		return email.split('@')[0].downcase
 
 	end
 

--- a/monitor_helper.rb
+++ b/monitor_helper.rb
@@ -34,7 +34,7 @@ module MonitorHelper
 	def user_space_exists(user_space_name, org_spaces)
 
 		org_spaces.each do |org_space|
-			if org_space["entity"]["name"] == user_space_name
+			if org_space["entity"]["name"].downcase == user_space_name
 				return true
 			end
 		end

--- a/spec/monitor_helper_spec.rb
+++ b/spec/monitor_helper_spec.rb
@@ -31,6 +31,7 @@ describe MonitorHelper do
 	it "should extract a valid sandbox space name from email" do
 
 		expect(monitor_helper_test.get_sandbox_space_name('john.doe@some.domain.gov')).to eq 'john.doe'
+		expect(monitor_helper_test.get_sandbox_space_name('John.Doe@some.domain.gov')).to eq 'john.doe'
 
 	end
 


### PR DESCRIPTION
Seeing some new users being added that are just mixed-case email versions of existing users  - e.g. seeing a new user `John.Doe@gsa.gov` when `john.doe@gsa.gov`  has already come thru the system.   This was causing them to look like new users - but an error would be thrown when trying to create that user space in the org.  Downcasing the user space names comparisons will catch these variations as existing users.