### PR TITLE
add a basic code climate config and corresponding badge to the README

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,15 @@
+---
+engines:
+  duplication:
+    enabled: false
+  fixme:
+    enabled: true
+  rubocop:
+    enabled: true
+
+ratings:
+  paths:
+  - "**.rb"
+ 
+exclude_paths:
+ - spec/*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # cg-sandbox-bot
+[![Code Climate](https://codeclimate.com/github/18F/cg-sandbox-bot/badges/gpa.svg)](https://codeclimate.com/github/18F/cg-sandbox-bot)
 
 Monitor CF cloud controller users and create a sandbox space for known domains.
 


### PR DESCRIPTION
As part of the Fedramp effort, we are required to ensure static code analysis is run on all 18F developed code that is part of the cloud.gov platform:  https://github.com/18F/cg-product/issues/260

In support of this effort, this PR adds a basic code climate configuration and badge to the README.