### PR TITLE
move pipeline from cg-deploy-bots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+*secrets.yml
+credentials.yml
 .env

--- a/ci/credentials.example.yml
+++ b/ci/credentials.example.yml
@@ -1,0 +1,21 @@
+# Deployment variables
+cf-api-endpoint-staging: 
+cf-api-endpoint-production: 
+cf-username: 
+cf-password-staging: 
+cf-password-production: 
+cf-organization: 
+cf-space: 
+cf-domain-name-staging: 
+cf-domain-name-production: 
+
+uaa-url-staging: 
+uaa-url-production: 
+client-id: 
+client-secret-staging: 
+client-secret-production: 
+
+slack-webhook-url: 
+slack-channel: 
+slack-username: 
+slack-icon-url: 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,0 +1,122 @@
+---
+resources:
+- name: git-sandbox-bot-stage
+  type: git
+  source:
+    uri: https://github.com/18f/cg-sandbox-bot
+    branch: staging
+- name: git-sandbox-bot-prod
+  type: git
+  source:
+    uri: https://github.com/18f/cg-sandbox-bot
+    branch: master
+- name: slack
+  type: slack-notification
+  source:
+    url: {{slack-webhook-url}}
+
+- name: sandbox-bot-stage-deployment
+  type: cf
+  source:
+    api: {{cf-api-endpoint-staging}}
+    username: {{cf-username}}
+    password: {{cf-password-staging}}
+    organization: {{cf-organization}}
+    space: {{cf-space}}
+    skip_cert_check: false
+- name: sandbox-bot-prod-deployment
+  type: cf
+  source:
+    api: {{cf-api-endpoint-production}}
+    username: {{cf-username}}
+    password: {{cf-password-production}}
+    organization: {{cf-organization}}
+    space: {{cf-space}}
+    skip_cert_check: false
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+
+jobs:
+- name: deploy-sandbox-bot-stage
+  serial: true
+  serial_groups:
+  - sandbox-bot
+  plan:
+  - aggregate:
+    - get: git-sandbox-bot-stage
+      trigger: true
+  - aggregate:
+    - put: sandbox-bot-stage-deployment
+      params:
+        manifest: git-sandbox-bot-stage/manifest-staging.yml
+        path: git-sandbox-bot-stage
+        current_app_name: sandbox-bot-staging
+        environment_variables:
+          DOMAIN_NAME: {{cf-domain-name-staging}}
+          CLIENT_ID: {{client-id}}
+          CLIENT_SECRET: {{client-secret-staging}}
+          UAA_URL: {{uaa-url-staging}}
+          SLACK_HOOK: {{slack-webhook-url}}
+  on_failure:
+    put: slack
+    params:
+      text: |
+        :x: FAILED to deploy $BUILD_PIPELINE_NAME on {{cf-api-endpoint-staging}}
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: {{slack-channel}}
+      username: {{slack-username}}
+      icon_url: {{slack-icon-url}}
+  on_success:
+    put: slack
+    params:
+      text: |
+        :white_check_mark: Successfully deployed $BUILD_PIPELINE_NAME on {{cf-api-endpoint-staging}}
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: {{slack-channel}}
+      username: {{slack-username}}
+      icon_url: {{slack-icon-url}}
+
+- name: deploy-sandbox-bot-prod
+  serial: true
+  serial_groups:
+  - sandbox-bot
+  plan:
+  - aggregate:
+    - get: git-sandbox-bot-prod
+      trigger: true
+    - get: sandbox-bot-stage-deployment
+      passed: [deploy-sandbox-bot-stage]
+  - aggregate:
+    - put: sandbox-bot-prod-deployment
+      params:
+        manifest: git-sandbox-bot-prod/manifest.yml
+        path: git-sandbox-bot-prod
+        current_app_name: sandbox-bot
+        environment_variables:
+          DOMAIN_NAME: {{cf-domain-name-production}}
+          CLIENT_ID: {{client-id}}
+          CLIENT_SECRET: {{client-secret-production}}
+          UAA_URL: {{uaa-url-production}}
+          SLACK_HOOK: {{slack-webhook-url}}
+  on_failure:
+    put: slack
+    params:
+      text: |
+        :x: FAILED to deploy $BUILD_PIPELINE_NAME on {{cf-api-endpoint-production}}
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: {{slack-channel}}
+      username: {{slack-username}}
+      icon_url: {{slack-icon-url}}
+  on_success:
+    put: slack
+    params:
+      text: |
+        :white_check_mark: Successfully deployed $BUILD_PIPELINE_NAME on {{cf-api-endpoint-production}}
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: {{slack-channel}}
+      username: {{slack-username}}
+      icon_url: {{slack-icon-url}}


### PR DESCRIPTION
Moves the pipeline from cg-deploy-bots (now depreciated) with the following changes:
- removes the migration-bot related resources
- Adds slack notifications
- Separate passwords for staging and production

