### PR TITLE
bot has gotten to the point it needs a tad more memory to do the job

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -60,7 +60,7 @@ jobs:
     file: git-sandbox-bot/integrate.yml
   - put: sandbox-bot-stage-deployment
     params:
-      manifest: git-sandbox-bot-integrated/manifest-staging.yml
+      manifest: git-sandbox-bot-integrated/manifest.yml
       path: git-sandbox-bot-integrated
       current_app_name: sandbox-bot-staging
       environment_variables:
@@ -70,6 +70,7 @@ jobs:
         UAA_URL: {{uaa-url-staging}}
         DOMAIN_CSV_PATH: ./current-federal.csv
         SLACK_HOOK: {{slack-webhook-url}}
+        DO_SLACK: false
   on_failure:
     put: slack
     params:
@@ -116,6 +117,7 @@ jobs:
         UAA_URL: {{uaa-url-production}}
         DOMAIN_CSV_PATH: ./current-federal.csv
         SLACK_HOOK: {{slack-webhook-url}}
+        DO_SLACK: true
   on_failure:
     put: slack
     params:

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -1,5 +1,0 @@
----
-inherit: manifest.yml
-name: sandbox-bot-staging
-env:
-  DO_SLACK: false

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,11 +1,10 @@
 ---
-memory: 128M
 applications:
 - name: sandbox-bot
   command: bundle && ruby ./monitor.rb
+  memory: 256M
   no-route: true
   health-check-type: none
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
-env:
-  SLEEP_TIMEOUT: 30
-  DO_SLACK: true
+  env:
+    SLEEP_TIMEOUT: 30


### PR DESCRIPTION
Also, no need for separate staging manifest, move the slack notify var into pipeline.